### PR TITLE
EDN support

### DIFF
--- a/src/wscljs/format.cljs
+++ b/src/wscljs/format.cljs
@@ -1,5 +1,6 @@
 (ns wscljs.format
-  (:refer-clojure :exclude [identity]))
+  (:refer-clojure :exclude [identity])
+  (:require [cljs.reader :as reader]))
 
 
 (defprotocol Format
@@ -20,3 +21,9 @@
   (reify Format
     (read  [_ s] (js->clj (js/JSON.parse s) :keywordize-keys true))
     (write [_ v] (js/JSON.stringify (clj->js v)))))
+
+(def edn
+  "Read and write data serialized as EDN."
+  (reify Format
+    (read [_ s] (reader/read-string s))
+    (write [_ v] (prn-str v))))

--- a/test/wscljs/client_test.cljs
+++ b/test/wscljs/client_test.cljs
@@ -77,3 +77,17 @@
                  (<! (timeout 1000))
                  (is (= data @recvd-data))
                  (done))))))
+
+(deftest test-edn
+  (testing "Receiving sent data over the socket connection with fmt/edn"
+    (async done
+           (go (let [data {:command "ping"}
+                     format fmt/edn
+                     recvd-data (atom nil)
+                     socket (ws/create wsurl {:on-message #(reset! recvd-data
+                                                                   (fmt/read format (.-data %)))})]
+                 (<! (timeout 1000))
+                 (ws/send socket data format)
+                 (<! (timeout 1000))
+                 (is (= data @recvd-data))
+                 (done))))))


### PR DESCRIPTION
Add support for EDN in format.cljs, and add test for it in client_test.cljs, patterned after existing test for JSON format.